### PR TITLE
[kb-github-tags] Use the Kitchen Busser Registry API to fetch cached GitHub tags.

### DIFF
--- a/libexec/kb-github-tags
+++ b/libexec/kb-github-tags
@@ -4,7 +4,7 @@
 require 'chef/rest'
 
 user, repo, splat = ARGV
-url = "https://kbr.nichol.ca/tags/#{user}/#{repo}"
+url = "http://kbr.nichol.ca/tags/#{user}/#{repo}"
 
 EXCEPTIONS = [ SocketError, Errno::ECONNREFUSED, Timeout::Error,
   Net::HTTPFatalError, Net::HTTPServerException ]

--- a/libexec/kb-github-tags
+++ b/libexec/kb-github-tags
@@ -4,14 +4,13 @@
 require 'chef/rest'
 
 user, repo, splat = ARGV
-url = "https://api.github.com/repos/#{user}/#{repo}/git/refs/tags"
+url = "https://kbr.nichol.ca/tags/#{user}/#{repo}"
 
 EXCEPTIONS = [ SocketError, Errno::ECONNREFUSED, Timeout::Error,
   Net::HTTPFatalError, Net::HTTPServerException ]
 
 begin
-  rest = Chef::REST.new(url, nil, nil, {})
-  puts rest.get_rest(url, false, {}).map { |t| t["ref"].split("/").last }.sort
+  puts Chef::REST.new(url, nil, nil, {}).get_rest(url, false, {})
 rescue *EXCEPTIONS => e
   if e.message == %{404 "Not Found"}
     puts "master"


### PR DESCRIPTION
This pushes GitHub tag lookup and API rate limiting concerns over to a new small API endpoint, tentatively called the Kitchen Busser Registry ([kbr](https://github.com/fnichol/kbr)).

This is pull request 1 of 2 which addresses #6.
